### PR TITLE
- 

### DIFF
--- a/chargily_epay_flutter/lib/chargily_api.dart
+++ b/chargily_epay_flutter/lib/chargily_api.dart
@@ -1,3 +1,5 @@
+// ignore_for_file: constant_identifier_names
+
 import 'package:dio/dio.dart' hide Headers;
 import 'package:json_annotation/json_annotation.dart';
 import 'package:retrofit/retrofit.dart';

--- a/chargily_epay_flutter/lib/chargily_api.g.dart
+++ b/chargily_epay_flutter/lib/chargily_api.g.dart
@@ -1,5 +1,7 @@
 // GENERATED CODE - DO NOT MODIFY BY HAND
 
+// ignore_for_file: unused_element
+
 part of 'chargily_api.dart';
 
 // **************************************************************************

--- a/chargily_epay_flutter/pubspec.yaml
+++ b/chargily_epay_flutter/pubspec.yaml
@@ -11,18 +11,18 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  retrofit: ^3.0.1+1
-  dio: ^4.0.6
+  retrofit: ^4.0.1
+  dio: ^5.3.2
   built_value: ^8.3.0
   json_annotation: ^4.7.0
   fluent_validation: ^2.0.0
-  logger: ^1.1.0
+  logger: ^2.0.1
 
 dev_dependencies:
   flutter_test:
     sdk: flutter
-  flutter_lints: ^1.0.0
-  retrofit_generator: ^4.0.1
+  flutter_lints: ^2.0.2
+  retrofit_generator: ^7.0.8
   build_runner: ^2.1.10
   json_serializable: ^6.2.0
   built_value_generator: ^8.3.0


### PR DESCRIPTION
- Upgraded dependencies on pubspec.yaml
To hide two warnings showed by lint:
- added ignore_for_file: unused_element to chargily_api.g.dart
- added ignore_for_file: constant_identifier_names to chargily_api.dart